### PR TITLE
fix: fails to run npm lint

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,8 +20,8 @@ jobs:
     - name: npm install, build, and test
       run: |
         npm ci
-        npm lint
-        npm run build --if-present
-        npm test
+        npm run lint
+        npm run build
+        npm run test
       env:
         CI: true


### PR DESCRIPTION
Issue was the result of copying the default template, which called 'npm lint' rather than 'npm run lint'. Updated the code so that the command should now run correctly.